### PR TITLE
Fixing php version.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": ">=7.1",
         "imanghafoori/laravel-terminator" : "*",
         "laravel/framework":"~5.1|6.*|7.*|8.*"
     },


### PR DESCRIPTION
There is an issue (so-far that I'm reading the source code) that the specified PHP version in composer.json doesn't match the sytaxes used in the source code. For example:

`/src/Core/ProxyClass.php`

![Screenshot from 2020-10-04 15-53-55](https://user-images.githubusercontent.com/31504728/95015505-21deb980-065a-11eb-8e6b-dcaf66ed107a.png)
